### PR TITLE
Hide exam content after grading

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -3,7 +3,7 @@
 // Uso: node scripts/validate.mjs ./data/sudamericana-trivia-v1.json
 
 import fs from 'node:fs/promises';
-import Ajv from 'ajv';
+import Ajv from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 
 const [,, targetPath = './data/sudamericana-trivia-v1.json'] = process.argv;

--- a/src/render.js
+++ b/src/render.js
@@ -154,9 +154,17 @@ export const handleSubmit = (state) => {
   renderResults(state);
 
   // Ocultar secciones del examen, mostrar resultados
-  document.getElementById('progress-section').hidden = true;
-  document.getElementById('questions-section').hidden = true;
-  document.getElementById('actions-section').hidden = true;
+  const progressSection = document.getElementById('progress-section');
+  const questionsSection = document.getElementById('questions-section');
+  const actionsSection = document.getElementById('actions-section');
+
+  progressSection.hidden = true;
+  actionsSection.hidden = true;
+
+  // Ocultar y limpiar preguntas para que solo quede la retroalimentación visible
+  questionsSection.hidden = true;
+  questionsSection.innerHTML = '';
+
   document.getElementById('results-section').hidden = false;
 };
 

--- a/src/render.js
+++ b/src/render.js
@@ -19,6 +19,8 @@ export const showQuiz = () => {
   document.getElementById('progress-section').hidden = false;
   document.getElementById('questions-section').hidden = false;
   document.getElementById('actions-section').hidden = false;
+  const submitBtn = document.getElementById('submit-btn');
+  if (submitBtn) submitBtn.hidden = false;
   // Ocultar landing
   document.getElementById('landing').hidden = true;
 };
@@ -135,6 +137,9 @@ export const updateProgressUI = (state) => {
   }
   const fill = document.getElementById('progress-fill');
   if (fill) fill.style.width = `${percent}%`;
+
+  const gotoFirst = document.getElementById('goto-first-missing');
+  if (gotoFirst) gotoFirst.hidden = answered === total;
 };
 
 export const handleSubmit = (state) => {
@@ -157,9 +162,11 @@ export const handleSubmit = (state) => {
   const progressSection = document.getElementById('progress-section');
   const questionsSection = document.getElementById('questions-section');
   const actionsSection = document.getElementById('actions-section');
+  const submitBtn = document.getElementById('submit-btn');
 
   progressSection.hidden = true;
   actionsSection.hidden = true;
+  if (submitBtn) submitBtn.hidden = true;
 
   // Ocultar y limpiar preguntas para que solo quede la retroalimentación visible
   questionsSection.hidden = true;


### PR DESCRIPTION
## Summary
- Clear question section after grading so only feedback is visible
- Use Ajv 2020 for JSON schema validation script

## Testing
- `npm run validate:exam`


------
https://chatgpt.com/codex/tasks/task_e_68acfb2873608323bfbf1b88f7e1d772